### PR TITLE
Pass sorting options through to getConversationsList

### DIFF
--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -373,8 +373,8 @@ class Conversation extends BaseModel
         }
 
         return $paginator
-            ->orderBy('c.updated_at', 'DESC')
-            ->orderBy('c.id', 'DESC')
+            ->orderBy('c.updated_at', $options['sorting'])
+            ->orderBy('c.id', $options['sorting'])
             ->distinct('c.id')
             ->paginate($options['perPage'], [$this->tablePrefix.'participation.*', 'c.*'], $options['pageName'], $options['page']);
     }

--- a/src/Services/ConversationService.php
+++ b/src/Services/ConversationService.php
@@ -110,6 +110,7 @@ class ConversationService
             'page'      => $this->page,
             'pageName'  => 'page',
             'filters'   => $this->filters,
+            'sorting'   => $this->sorting,
         ]);
     }
 


### PR DESCRIPTION
The sorting options for conversation lists did not work, this enables support for sorting by newest or oldest